### PR TITLE
build(npm): add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.idea/
+node_modules/
+.vscode
+dataMock/
+src/
+package-lock.json
+bin/create-api.js
+model


### PR DESCRIPTION
This fixes a fatal module loader error the package published to NPM, as
reported in issue #1.